### PR TITLE
Fixes an issue where calling open twice on MQTTCFSocketTransport crashes

### DIFF
--- a/MQTTClient/MQTTClient/MQTTCFSocketDecoder.m
+++ b/MQTTClient/MQTTClient/MQTTCFSocketDecoder.m
@@ -33,6 +33,10 @@
     }
 }
 
+- (void)dealloc {
+    [self close];
+}
+
 - (void)close {
     [self.stream close];
     [self.stream removeFromRunLoop:self.runLoop forMode:self.runLoopMode];

--- a/MQTTClient/MQTTClient/MQTTCFSocketEncoder.m
+++ b/MQTTClient/MQTTClient/MQTTCFSocketEncoder.m
@@ -28,6 +28,10 @@
     return self;
 }
 
+- (void)dealloc {
+    [self close];
+}
+
 - (void)open {
     [self.stream setDelegate:self];
     [self.stream scheduleInRunLoop:self.runLoop forMode:self.runLoopMode];

--- a/MQTTClient/MQTTClient/MQTTCFSocketTransport.m
+++ b/MQTTClient/MQTTClient/MQTTCFSocketTransport.m
@@ -68,6 +68,7 @@
     }
     
     if(!connectError){
+        self.encoder.delegate = nil;
         self.encoder = [[MQTTCFSocketEncoder alloc] init];
         self.encoder.stream = CFBridgingRelease(writeStream);
         self.encoder.runLoop = self.runLoop;
@@ -75,6 +76,7 @@
         self.encoder.delegate = self;
         [self.encoder open];
         
+        self.decoder.delegate = nil;
         self.decoder = [[MQTTCFSocketDecoder alloc] init];
         self.decoder.stream =  CFBridgingRelease(readStream);
         self.decoder.runLoop = self.runLoop;

--- a/MQTTClient/MQTTClient/MQTTDecoder.m
+++ b/MQTTClient/MQTTClient/MQTTDecoder.m
@@ -24,6 +24,10 @@
     return self;
 }
 
+- (void)dealloc {
+    [self close];
+}
+
 - (void)decodeMessage:(NSData *)data {
     NSInputStream *stream = [NSInputStream inputStreamWithData:data];
     [self openStream:stream];


### PR DESCRIPTION
This was due to unclosed encoders and decoders
