### PR TITLE
Disables verbose MQTT logs in DEBUG configuration

### DIFF
--- a/MQTTClient/MQTTClient/MQTTLog.h
+++ b/MQTTClient/MQTTClient/MQTTLog.h
@@ -25,7 +25,7 @@
     #endif
 #else
     #ifdef DEBUG
-        #define DDLogVerbose NSLog
+        #define DDLogVerbose(...)
         #define DDLogWarn NSLog
         #define DDLogInfo NSLog
         #define DDLogError NSLog

--- a/MQTTClient/MQTTClient/MQTTSession.m
+++ b/MQTTClient/MQTTClient/MQTTSession.m
@@ -462,7 +462,7 @@
 }
 
 - (void)decoder:(MQTTDecoder*)sender handleEvent:(MQTTDecoderEvent)eventCode error:(NSError *)error {
-    NSArray *events = @[
+    __unused NSArray *events = @[
                         @"MQTTDecoderEventProtocolError",
                         @"MQTTDecoderEventConnectionClosed",
                         @"MQTTDecoderEventConnectionError"

--- a/MQTTClient/MQTTClient/MQTTSessionManager.m
+++ b/MQTTClient/MQTTClient/MQTTSessionManager.m
@@ -324,7 +324,7 @@
 - (void)handleEvent:(MQTTSession *)session event:(MQTTSessionEvent)eventCode error:(NSError *)error
 {
 #ifdef DEBUG
-    const NSDictionary *events = @{
+    __unused const NSDictionary *events = @{
                                    @(MQTTSessionEventConnected): @"connected",
                                    @(MQTTSessionEventConnectionRefused): @"connection refused",
                                    @(MQTTSessionEventConnectionClosed): @"connection closed",


### PR DESCRIPTION
Verbose logs create way too much noise to spot any other potentially useful logs.
